### PR TITLE
Fixed small reflection warning by adding a type hint.

### DIFF
--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -56,7 +56,7 @@
   {:arglists '([request body-value])}
   (fn [request x] (type x)))
 
-(defmethod body String [request string]
+(defmethod body String [request ^String string]
   (body request (.getBytes string)))
 
 (defmethod body (class (byte-array 0)) [request bytes]


### PR DESCRIPTION
`lein eastwood` gave me a reflection warning in request.clj. It annoyed me a little so i added a type hint in request.clj. 