### PR TITLE
DELETE requests also send parameters in URL

### DIFF
--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -96,6 +96,6 @@
                     :headers        {"host" (if port
                                               (str host ":" port)
                                               host)}}]
-       (if (#{:get :head} method)
+       (if (#{:get :head :delete} method)
          (merge-query request params)
          (body request params)))))


### PR DESCRIPTION
It's a proposal to make `DELETE` requests behave like `GET` and `HEAD` when sending parameters.

Reference of an interesting discussion about the subject: https://github.com/AFNetworking/AFNetworking/issues/179.