### PR TITLE
Respect JSON content-type when encoding request body.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.5.1"]
+                 [org.clojure/data.json "0.2.6"]
                  [ring/ring-codec "1.0.0"]]
   :plugins [[codox "0.8.13"]]
   :codox {:project {:name "Ring-Mock"}}

--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -1,6 +1,7 @@
 (ns ring.mock.request
   "Functions to create mock request maps."
   (:require [clojure.string :as string]
+            [clojure.data.json :as json]
             [ring.util.codec :as codec]))
 
 (defn- encode-params
@@ -65,9 +66,11 @@
       (assoc :body (java.io.ByteArrayInputStream. bytes))))
 
 (defmethod body java.util.Map [request params]
-  (-> request
+  (if (= (:content-type request) "application/json")
+    (body request (json/write-str params))
+    (-> request
       (content-type "application/x-www-form-urlencoded")
-      (body (encode-params params))))
+      (body (encode-params params)))))
 
 (defmethod body nil [request params]
   request)

--- a/test/ring/mock/request_test.clj
+++ b/test/ring/mock/request_test.clj
@@ -126,6 +126,9 @@
       (is (= (:content-length resp) 26))
       (is (= (:content-type resp)
              "application/x-www-form-urlencoded"))))
+  (testing "map body on json request"
+    (let [resp (body {:content-type "application/json"} (array-map :foo "bar"))]
+      (is (= (:content-type resp) "application/json"))))
   (testing "bytes body"
     (let [resp (body {} (.getBytes "foo"))]
       (is (instance? java.io.InputStream (:body resp)))


### PR DESCRIPTION
Normally, when ring.mock.request/body receives a params map, it sets the request content-type to "x-www-form-urlencoded" and urlencodes the params; that is, `{:a 1 :b 2}` becomes `"a=1&b=2"`.

If the content-type of the request is "application/json", it is appropriate to preserve the content-type, and encode the params map as a JSON string; that is, `{:a 1 :b 2}` becomes `"{\"a\": 1, \"b\": 2}"`.

This should make it easier to use ring.mock.request to test JSON APIs.