### PR TITLE
Update README to properly reference json-body in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add the following development dependency to your `project.clj` file:
           
 (deftest your-json-handler-test
   (is (= (your-handler (-> (mock/request :post "/api/endpoint")
-                           (json-body {:foo "bar"})))
+                           (mock/json-body {:foo "bar"})))
          {:status 201
           :headers {"content-type" "application/json"}
           :body {:key "your expected result"}})))


### PR DESCRIPTION
Also, it would be great to release new version so that `json-body` is available 👍 