### PR TITLE
Change remote-addr to 127.0.0.1

### DIFF
--- a/src/ring/mock/request.clj
+++ b/src/ring/mock/request.clj
@@ -106,7 +106,7 @@
            request {:protocol       "HTTP/1.1"
                     :server-port    (or port (default-port scheme))
                     :server-name    host
-                    :remote-addr    "localhost"
+                    :remote-addr    "127.0.0.1"
                     :uri            (if (string/blank? path) "/" path)
                     :scheme         scheme
                     :request-method method

--- a/test/ring/mock/request_test.clj
+++ b/test/ring/mock/request_test.clj
@@ -9,7 +9,7 @@
            {:protocol "HTTP/1.1"
             :server-port 80
             :server-name "localhost"
-            :remote-addr "localhost"
+            :remote-addr "127.0.0.1"
             :uri "/foo"
             :scheme :http
             :request-method :get
@@ -22,7 +22,7 @@
              {:protocol "HTTP/1.1"
               :server-port 8443
               :server-name "example.com"
-              :remote-addr "localhost"
+              :remote-addr "127.0.0.1"
               :uri "/foo"
               :query-string "bar=baz"
               :scheme :https


### PR DESCRIPTION
Ring request :remote-addr is an IP address, not a hostname.

https://github.com/ring-clojure/ring/wiki/Concepts#requests
https://github.com/ring-clojure/ring/blob/95e4ca25d5b98c45f927b32b5c3c85c21c999d96/ring-servlet/src/ring/util/servlet.clj#L42
https://docs.oracle.com/javaee/6/api/javax/servlet/ServletRequest.html#getRemoteAddr()