### PR TITLE
Update dependencies for ring-mock

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,17 +4,21 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [cheshire "5.8.1"]
-                 [ring/ring-codec "1.1.1"]]
+                 [cheshire "6.0.0"]
+                 [ring/ring-codec "1.3.0"]]
   :plugins [[lein-codox "0.10.3"]]
   :codox
   {:project     {:name "Ring-Mock"}
    :output-path "codox"
    :source-uri  "https://github.com/ring-clojure/ring-mock/blob/{version}/{filepath}#L{line}"}
-  :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10" "test"]}
+  :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11:+1.12" "test"]}
   :profiles
   {:1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]
                          [ring/ring-spec "0.0.4"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]
+                         [ring/ring-spec "0.0.4"]]}
+   :1.11 {:dependencies [[org.clojure/clojure "1.11.0"]
+                         [ring/ring-spec "0.0.4"]]}
+   :1.12 {:dependencies [[org.clojure/clojure "1.12.0"]
                          [ring/ring-spec "0.0.4"]]}})


### PR DESCRIPTION
High snyk vulnerabilities are showing up with the latest version. This updates all dependencies and passes all tests.